### PR TITLE
feat: moved font import to typography.css

### DIFF
--- a/apps/web/src/app/_styles/globals.css
+++ b/apps/web/src/app/_styles/globals.css
@@ -1,6 +1,3 @@
-/* External fonts used on the project */
-@import url('https://fonts.cdnfonts.com/css/sharp-sans');
-
 /* Tailwind import */
 @import 'tailwindcss';
 @import './typography.css';

--- a/apps/web/src/app/_styles/typography.css
+++ b/apps/web/src/app/_styles/typography.css
@@ -2,6 +2,10 @@
 /* Responsive Typography Setup   */
 /* ============================= */
 
+/* External fonts used on the project */
+@import url('https://fonts.cdnfonts.com/css/sharp-sans');
+
+
 /* 
   Define custom properties for font sizes based on viewport width.
   4.10256410256vw: 16px / 390px * 100vw for portrait


### PR DESCRIPTION
This pull request moves the external font import for Sharp Sans from the global styles file to the typography-specific stylesheet. This change helps organize font-related imports with other typography settings, making the codebase more maintainable.

**Stylesheet organization:**

* Moved the Sharp Sans external font import from `globals.css` to `typography.css`, grouping font imports with other typography-related styles. [[1]](diffhunk://#diff-f23f20e05b21a5460e1c2b14558b23086a1bbfef84fb377013e875fd5dc0071eL1-L3) [[2]](diffhunk://#diff-4b89f4c449856e265528b95291d4b7789815c159adae03b7d384a372687ed3a8R5-R8)