### PR TITLE
feat: improve error handling

### DIFF
--- a/apps/web/src/app/a/[id]/page.tsx
+++ b/apps/web/src/app/a/[id]/page.tsx
@@ -8,6 +8,7 @@ interface PageProps {
 
 export default async function DynamicPage({ params }: PageProps) {
   const { id } = await params;
+
   const avatarData = await getUserAvatar(id);
 
   if (!avatarData?.url) return redirect('/');

--- a/apps/web/src/components/Bento/index.tsx
+++ b/apps/web/src/components/Bento/index.tsx
@@ -1,10 +1,9 @@
-import { FC, ReactNode } from 'react';
-import Image, { StaticImageData, ImageProps } from 'next/image';
 import clsx from 'clsx';
+import Image, { ImageProps, StaticImageData } from 'next/image';
+import type { FC, PropsWithChildren } from 'react';
 
-export interface BentoProps {
+export interface BentoProps extends PropsWithChildren {
   className?: string;
-  children?: ReactNode;
   image?: StaticImageData | string;
   imageSrcLandscape?: StaticImageData | string;
   imageSrcPortrait?: StaticImageData | string;
@@ -39,7 +38,6 @@ const Bento: FC<BentoProps> = ({
   imageProps,
   imagePropsPortrait,
   imagePropsLandscape,
-  ...restProps
 }) => (
   <div className={clsx(defaultStyle, className)}>
     {image && (
@@ -62,7 +60,7 @@ const Bento: FC<BentoProps> = ({
     {imageSrcLandscape && (
       <Image
         src={imageSrcLandscape}
-        alt={imageAlt ?? ''}
+        alt={imageAltLandscape ?? imageAlt ?? ''}
         fill
         sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
         className={clsx(

--- a/apps/web/src/components/Modal/index.tsx
+++ b/apps/web/src/components/Modal/index.tsx
@@ -1,16 +1,15 @@
-import type { FC, PropsWithChildren, ReactNode } from 'react';
 import {
-  Modal as HeroModal,
-  ModalContent,
-  ModalBody,
   Button,
+  Modal as HeroModal,
+  ModalBody,
+  ModalContent,
   type ModalProps,
 } from '@heroui/react';
 import Image from 'next/image';
+import type { FC, PropsWithChildren } from 'react';
 import ThreeDots from '../ThreeDots';
 
 interface CustomModalProps extends ModalProps {
-  headerContent?: ReactNode;
   modalTitle?: string;
 }
 
@@ -18,7 +17,6 @@ const Modal: FC<PropsWithChildren<CustomModalProps>> = ({
   children,
   isOpen,
   onOpenChange,
-  headerContent,
   modalTitle = 'Build a Billionaire',
   ...modalProps
 }) => {

--- a/apps/web/src/components/PrimaryFlow/AvatarBento/index.tsx
+++ b/apps/web/src/components/PrimaryFlow/AvatarBento/index.tsx
@@ -1,14 +1,14 @@
+import { evaluateFlag } from '@/app/flags';
 import Bento, { type BentoProps } from '@/components/Bento';
 import BentoPlaypenComingSoon from '@/components/BentoPlaypenComingSoon';
 import BentoPlaypenSelfie from '@/components/BentoPlaypenSelfie';
 import type { AvatarData } from '@/types';
-import Image, { ImageProps } from 'next/image';
+import Image from 'next/image';
 import type { FC } from 'react';
 import BrowserBento, { type BrowserBentoProps } from '../../BrowserBento';
 import GetStarted, { type GetStartedProps } from '../GetStarted';
 import { PrimaryContextProvider } from '../PrimaryFlowContext';
 import AvatarView from './AvatarView';
-import { evaluateFlag } from '@/app/flags';
 
 export interface AvatarBentoProps extends BentoProps, BrowserBentoProps {
   /**
@@ -35,12 +35,8 @@ function hasAvatar(data?: AvatarData | null): data is AvatarData {
 const AvatarBento: FC<AvatarBentoProps> = async ({
   avatarData,
   primaryFlowData,
-  image,
   imageSrcLandscape,
   imageSrcPortrait,
-  imageProps,
-  imagePropsPortrait,
-  imagePropsLandscape,
   ...bentoProps
 }) => {
   const hasGeneratedAvatar = hasAvatar(avatarData);

--- a/apps/web/src/components/PrimaryFlow/ChoiceBento/index.tsx
+++ b/apps/web/src/components/PrimaryFlow/ChoiceBento/index.tsx
@@ -1,4 +1,4 @@
-import { choiceGroupMap, choiceMap, groupDescriptionMap } from '@/constants/choice-map';
+import { choiceMap, groupDescriptionMap } from '@/constants/choice-map';
 import type { ChoiceGroup } from '@/types';
 import Image from 'next/image';
 import type { FC } from 'react';
@@ -30,8 +30,8 @@ const ChoiceBento: FC<ChoiceBentoProps> = ({ activeGroup }) => {
       {/* Mobile layout */}
       <div className="flex flex-col h-full landscape:hidden">
         {/* Icon row or spacer */}
-        <div className="pt-[5rem] mb-6">
-          <SelectedIconsRow />
+        <div className="pt-[6rem] mb-4">
+          <SelectedIconsRow excludeGroup={activeGroup} />
         </div>
 
         {/* Centered text content */}

--- a/apps/web/src/components/PrimaryFlow/CompletionScreen/index.tsx
+++ b/apps/web/src/components/PrimaryFlow/CompletionScreen/index.tsx
@@ -4,13 +4,14 @@ import { choiceGroupMap } from '@/constants/choice-map';
 import type { ChoiceGroup } from '@/types';
 import { saveUserAvatar } from '@/utils/actions/save-user-avatar';
 import Image from 'next/image';
-import { type FC } from 'react';
+import { type FC, useState } from 'react';
 import BrowserBento from '../../BrowserBento';
 import ProgressBar from '../../ProgressBar';
 import { usePrimaryFlowContext } from '../PrimaryFlowContext';
 
 const CompletionScreen: FC = () => {
   const { userChoices, avatarData } = usePrimaryFlowContext();
+  const [imageLoaded, setImageLoaded] = useState(false);
 
   // Get all selected choices in the correct order
   const groupKeys = Object.keys(choiceGroupMap) as ChoiceGroup[];
@@ -250,12 +251,23 @@ const CompletionScreen: FC = () => {
         >
           {/* Avatar Background Image */}
           {avatarData && (
-            <Image
-              src={avatarData.url}
-              alt="Generated Billionaire Avatar"
-              fill
-              className="object-cover object-top"
-            />
+            <>
+              {/* Loading shimmer background */}
+              {!imageLoaded && (
+                <div className="absolute inset-0 bg-white overflow-hidden">
+                  <div className="absolute inset-0 -translate-x-full bg-gradient-to-r from-transparent via-gray-400 to-transparent animate-shimmer w-full h-full"></div>
+                </div>
+              )}
+              <Image
+                src={avatarData.url}
+                alt="Generated Billionaire Avatar"
+                fill
+                className={`object-cover object-top transition-opacity duration-500 ${
+                  imageLoaded ? 'opacity-100' : 'opacity-0'
+                }`}
+                onLoad={() => setImageLoaded(true)}
+              />
+            </>
           )}
 
           {/* BrowserBento overlay - for both mobile and landscape */}

--- a/apps/web/src/components/PrimaryFlow/ConfirmSelectionScreen/index.tsx
+++ b/apps/web/src/components/PrimaryFlow/ConfirmSelectionScreen/index.tsx
@@ -11,7 +11,7 @@ interface ConfirmSelectionScreenProps {
 }
 
 const ConfirmSelectionScreen: FC<ConfirmSelectionScreenProps> = ({ activeGroup }) => {
-  const { userChoices, setShowConfirmation, setActiveGroup, setAvatarData } =
+  const { userChoices, setShowConfirmation, setActiveGroup, setAvatarData, reset } =
     usePrimaryFlowContext();
   const selectedConfig = userChoices[activeGroup];
 
@@ -34,14 +34,11 @@ const ConfirmSelectionScreen: FC<ConfirmSelectionScreenProps> = ({ activeGroup }
         .filter((group) => userChoices[group])
         .map((group) => userChoices[group]!.id);
 
-      try {
-        const result = await generateAvatar(allChoices);
-        if (result) {
-          setAvatarData(result);
-        }
-      } catch (error) {
-        console.error('Error generating avatar:', error);
-      }
+      generateAvatar(allChoices)
+        .then((data) => setAvatarData(data))
+        .catch(() => {
+          reset();
+        });
     }
   };
 
@@ -61,8 +58,8 @@ const ConfirmSelectionScreen: FC<ConfirmSelectionScreenProps> = ({ activeGroup }
       {/* Mobile layout */}
       <div className="flex flex-col h-full landscape:hidden">
         {/* Icon row */}
-        <div className="pt-[2.625rem]">
-          <SelectedIconsRow className="mb-6" excludeGroup={activeGroup} />
+        <div className="pt-[6.625rem] mb-[-2rem]">
+          <SelectedIconsRow excludeGroup={activeGroup} />
         </div>
 
         {/* Text content - appears before icon on mobile */}
@@ -97,7 +94,10 @@ const ConfirmSelectionScreen: FC<ConfirmSelectionScreenProps> = ({ activeGroup }
       </div>
 
       {/* Landscape layout - keep original structure */}
-      <div className="hidden landscape:flex landscape:flex-col landscape:items-center landscape:mt-8 landscape:flex-col-reverse">
+      <div className="hidden landscape:flex landscape:flex-col landscape:items-center landscape:mt-12 landscape:flex-col-reverse">
+        <div className="pt-[2.625rem]">
+          <SelectedIconsRow className="mb-6" excludeGroup={activeGroup} />
+        </div>
         {/* Text content */}
         <div className="text-center space-y-4 mt-4">
           <h1 className="text-5xl-custom font-sharp font-bold text-common-ash capitalize">

--- a/apps/web/src/components/PrimaryFlow/GetStarted/index.tsx
+++ b/apps/web/src/components/PrimaryFlow/GetStarted/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { choiceGroupMap } from '@/constants/choice-map';
-import { Button, useDisclosure } from '@heroui/react';
+import { useDisclosure } from '@heroui/react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { type FC } from 'react';
 import Modal from '../../Modal';

--- a/apps/web/src/components/PrimaryFlow/Intro/index.tsx
+++ b/apps/web/src/components/PrimaryFlow/Intro/index.tsx
@@ -39,10 +39,10 @@ const Intro: FC<IntroProps> = ({
       groupKeys.filter((group) => randomChoices[group]).map((group) => randomChoices[group]!.id),
     )
       .then((avatarData) => setAvatarData(avatarData))
-      .catch((e) => {
+      .catch(() => {
         reset();
       });
-  }, [setUserChoices, setAvatarData]);
+  }, [setUserChoices, setAvatarData, reset]);
 
   return (
     <div className="relative p-4 flex flex-col items-center justify-center min-h-screen overflow-hidden landscape:flex-row landscape:gap-32 landscape:px-16 landscape:pt-[6rem] landscape:pb-40 landscape:h-full landscape:min-h-0 landscape:items-stretch landscape:justify-start">

--- a/apps/web/src/components/PrimaryFlow/PrimaryFlowContext.tsx
+++ b/apps/web/src/components/PrimaryFlow/PrimaryFlowContext.tsx
@@ -4,7 +4,6 @@ import { ChoiceGroup, type AvatarData, type ChoiceConfig } from '@/types';
 import {
   createContext,
   useContext,
-  useMemo,
   useState,
   type Dispatch,
   type FC,

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -75,12 +75,25 @@ body {
   }
 }
 
+@keyframes shimmer {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+
 .animate-scroll-without-pause {
   animation: ticker-horizontal-infinite-scroll 20s linear infinite;
 }
 
 .animate-scroll-with-pause {
   animation: ticker-horizontal-infinite-scroll 20s linear infinite;
+}
+
+.animate-shimmer {
+  animation: shimmer 2s linear infinite;
 }
 
 /* Pause on hover */

--- a/apps/web/src/utils/actions/get-user-avatar.ts
+++ b/apps/web/src/utils/actions/get-user-avatar.ts
@@ -16,7 +16,9 @@ export async function getUserAvatar(userUuid: string): Promise<AvatarData | null
       .eq('uuid', userUuid)
       .single<{ avatar_id: string }>();
 
-    if (userError || !user?.avatar_id) return null;
+    if (userError || !user?.avatar_id) {
+      throw new Error(userError?.message || 'User not found.');
+    }
 
     // Get avatar data using the avatar_id
     const { data: avatar, error: avatarError } = await supabase
@@ -25,7 +27,9 @@ export async function getUserAvatar(userUuid: string): Promise<AvatarData | null
       .eq('id', user.avatar_id)
       .single<Database['public']['Tables']['avatars']['Row']>();
 
-    if (avatarError || !avatar) return null;
+    if (avatarError || !avatar) {
+      throw new Error(avatarError?.message || 'Could no retrieve user avatar.');
+    }
 
     return {
       url: buildImageUrl(`${avatar.combination_key}.png`),
@@ -34,6 +38,8 @@ export async function getUserAvatar(userUuid: string): Promise<AvatarData | null
       uuid: userUuid,
     };
   } catch (e) {
+    // This will be available via server logs.
+    console.error(e);
     return null;
   }
 }


### PR DESCRIPTION
- Improve error handling by re-throwing so consumers and reset the state (we should implement an error message, is not in the designs)
- Log errors since they will be in the server and will be useful to have them there.
- Improve image loading by include a skeleton white background for image. This is because the text in the image is loaded before the actual image can be displayed, so this state makes the UI look nicer while the image loads.
- Fix all lint warnings.
- Some minor UI improvements in modal.