### PR TITLE
feat: include avatar gen in multiple places

### DIFF
--- a/apps/web/src/app/a/[id]/page.client.tsx
+++ b/apps/web/src/app/a/[id]/page.client.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { usePrimaryFlowContext } from '@/components/PrimaryFlow/PrimaryFlowContext';
+import type { AvatarData } from '@/types';
+import { useEffect, type FC, type PropsWithChildren } from 'react';
+
+interface ClientPageWrapperProps extends PropsWithChildren {
+  avatarData?: AvatarData | null;
+}
+
+const ClientPageWrapper: FC<ClientPageWrapperProps> = ({ avatarData, children }) => {
+  const { setAvatarData } = usePrimaryFlowContext();
+
+  useEffect(() => {
+    if (avatarData) {
+      setAvatarData(avatarData);
+    }
+  }, [avatarData, setAvatarData]);
+
+  return <>{children}</>;
+};
+
+export default ClientPageWrapper;

--- a/apps/web/src/app/a/[id]/page.tsx
+++ b/apps/web/src/app/a/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { getUserAvatar } from '@/utils/actions/get-user-avatar';
 import SharedPage from '../../shared-page';
 import { redirect } from 'next/navigation';
+import ClientPageWrapper from './page.client';
 
 interface PageProps {
   params: Promise<{ id: string }>;
@@ -13,5 +14,9 @@ export default async function DynamicPage({ params }: PageProps) {
 
   if (!avatarData?.url) return redirect('/');
 
-  return <SharedPage avatarData={avatarData} />;
+  return (
+    <ClientPageWrapper avatarData={avatarData}>
+      <SharedPage avatarData={avatarData} />
+    </ClientPageWrapper>
+  );
 }

--- a/apps/web/src/app/providers.tsx
+++ b/apps/web/src/app/providers.tsx
@@ -1,7 +1,12 @@
 'use client';
 
+import { PrimaryContextProvider } from '@/components/PrimaryFlow/PrimaryFlowContext';
 import { HeroUIProvider } from '@heroui/react';
 
 export function Providers({ children }: { children: React.ReactNode }) {
-  return <HeroUIProvider>{children}</HeroUIProvider>;
+  return (
+    <HeroUIProvider>
+      <PrimaryContextProvider initialData={null}>{children}</PrimaryContextProvider>
+    </HeroUIProvider>
+  );
 }

--- a/apps/web/src/app/shared-page.tsx
+++ b/apps/web/src/app/shared-page.tsx
@@ -1,14 +1,15 @@
 import { evaluateFlag } from '@/app/flags';
+import BentoDual from '@/components/BentoDual';
+import CountDown from '@/components/CountDown';
+import GalleryBentoLarge from '@/components/GalleryBentoLarge';
+import GalleryBentoSmall from '@/components/GalleryBentoSmall';
+import AvatarBento from '@/components/PrimaryFlow/AvatarBento';
+import Ticker from '@/components/Ticker';
+import Window from '@/components/Window';
+import type { AvatarData } from '@/types';
+import { avatarBentoData } from '@/utils/constants';
 import Image from 'next/image';
 import Link from 'next/link';
-import Ticker from '@/components/Ticker';
-import type { AvatarData } from '@/types';
-import AvatarBento, { type AvatarBentoProps } from '@/components/PrimaryFlow/AvatarBento';
-import GalleryBentoSmall from '@/components/GalleryBentoSmall';
-import GalleryBentoLarge from '@/components/GalleryBentoLarge';
-import BentoDual from '@/components/BentoDual';
-import Window from '@/components/Window';
-import CountDown from '@/components/CountDown';
 
 interface TickerItem {
   id?: number;
@@ -35,22 +36,6 @@ const tickerData: TickerItem[] = [
     emoji: '💰',
   },
 ];
-
-const avatarBentoData: AvatarBentoProps = {
-  primaryFlowData: {
-    triggerClassNames:
-      'absolute left-[5rem] landscape:left-[8.125rem] top-[17rem] landscape:top-[18.5rem] px-[3rem] landscape:px-[2.125rem] py-[0.75rem] bg-charcoal/30 rotate-[9deg] landscape:rotate-0 transition-[bg-color, color] transition-transform duration-600 group-hover:rotate-[-12deg] group-hover:bg-accent group-hover:text-charcoal',
-    ctaText: 'Get Started',
-    title: 'Make Space a Better Place. Add a Billionaire.',
-    description:
-      'Why should billionaires be the only ones sending billionaires to space? WE want to send billionaires to space! Build your own and reclaim your data independence!',
-    createAvatarCtaText: 'Start Building Your Billionaire',
-    randomAvatarCtaText: 'Create a Random Billionaire',
-  },
-  imageSrcLandscape: '/assets/images/avatar-square.webp',
-  imageSrcPortrait: '/assets/images/avatar-portrait.png',
-  imageAlt: '', // Decorative image
-};
 
 interface PageProps {
   avatarData?: AvatarData | null;

--- a/apps/web/src/components/CountDown/index.tsx
+++ b/apps/web/src/components/CountDown/index.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import { FC, useEffect, useState } from 'react';
-import Bento from '../Bento';
+import { avatarBentoData } from '@/utils/constants';
+import clsx from 'clsx';
 import Image from 'next/image';
 import Link from 'next/link';
-import clsx from 'clsx';
+import { FC, useEffect, useState } from 'react';
+import Bento from '../Bento';
+import GetStarted from '../PrimaryFlow/GetStarted';
 
 export interface CountDownProps {
   targetDate: string; // Format "2025-10-10T23:59:59-05:00"
@@ -59,13 +61,13 @@ const CountDown: FC<CountDownProps> = ({ targetDate, className }) => {
               rocket, built with Sent Into Space, carrying the absurd creations of a community that
               refused to play by Big Tech&apos;s rules.
             </p>
-            <Link
-              href="#"
-              className="secondary-button hidden landscape:flex"
-              title="Generate an avatar"
-            >
-              Build a Billionaire
-            </Link>
+            {avatarBentoData?.primaryFlowData && (
+              <GetStarted
+                {...avatarBentoData.primaryFlowData}
+                ctaText="Build a Billionaire"
+                triggerClassNames="secondary-button hidden landscape:flex"
+              />
+            )}
           </div>
           <div className="w-full flex flex-col items-end">
             <div className="relative w-fit bg-gradient-to-r from-secondary-blue to-secondary-purple rounded-lg p-4 pl-8 landscape:p-6">

--- a/apps/web/src/components/Footer/index.tsx
+++ b/apps/web/src/components/Footer/index.tsx
@@ -1,9 +1,11 @@
 'use client';
 
+import { avatarBentoData } from '@/utils/constants';
 import Image from 'next/image';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { FC } from 'react';
+import GetStarted from '../PrimaryFlow/GetStarted';
 
 export interface FooterProps {
   links: {
@@ -107,9 +109,13 @@ const Footer: FC<FooterProps> = ({ links, socials, ctaCopy, ctaLabel }) => {
               </span>
             ))}
           </p>
-          <Link href="#" className="secondary-button" title="Build an avatar now">
-            {ctaLabel}
-          </Link>
+          {avatarBentoData?.primaryFlowData && (
+            <GetStarted
+              {...avatarBentoData.primaryFlowData}
+              ctaText={ctaLabel}
+              triggerClassNames="secondary-button"
+            />
+          )}
         </div>
         <p className="landscape:self-end">
           <Link

--- a/apps/web/src/components/PrimaryFlow/AvatarBento/AvatarView.tsx
+++ b/apps/web/src/components/PrimaryFlow/AvatarBento/AvatarView.tsx
@@ -93,7 +93,7 @@ const AvatarView: FC<AvatarData> = ({ url, name, bio, uuid }) => {
           <BrowserBento white>
             <div className="flex flex-col gap-1 p-[1.5rem]">
               <span className="text-charcoal text-base font-semibold leading-6">
-                Meet <span className="text-secondary-purple font-extrabold">{name}</span> - {bio}
+                Meet <span className="text-secondary-purple font-extrabold capitalize">{name}</span> - {bio}
               </span>
             </div>
           </BrowserBento>

--- a/apps/web/src/components/PrimaryFlow/AvatarBento/index.tsx
+++ b/apps/web/src/components/PrimaryFlow/AvatarBento/index.tsx
@@ -3,11 +3,10 @@ import Bento, { type BentoProps } from '@/components/Bento';
 import BentoPlaypenComingSoon from '@/components/BentoPlaypenComingSoon';
 import BentoPlaypenSelfie from '@/components/BentoPlaypenSelfie';
 import type { AvatarData } from '@/types';
-import Image, { ImageProps } from 'next/image';
+import Image from 'next/image';
 import type { FC } from 'react';
 import BrowserBento, { type BrowserBentoProps } from '../../BrowserBento';
 import GetStarted, { type GetStartedProps } from '../GetStarted';
-import { PrimaryContextProvider } from '../PrimaryFlowContext';
 import AvatarView from './AvatarView';
 
 export interface AvatarBentoProps extends BentoProps, BrowserBentoProps {
@@ -84,11 +83,7 @@ const AvatarBento: FC<AvatarBentoProps> = async ({
             <AvatarView {...avatarData} />
           ) : (
             <>
-              {primaryFlowData && (
-                <PrimaryContextProvider initialData={avatarData || null}>
-                  <GetStarted {...primaryFlowData} />
-                </PrimaryContextProvider>
-              )}
+              {primaryFlowData && <GetStarted {...primaryFlowData} />}
 
               <div
                 className="absolute z-20 bottom-0 w-full h-[14.3125rem] px-4 pb-4

--- a/apps/web/src/components/PrimaryFlow/CompletionScreen/index.tsx
+++ b/apps/web/src/components/PrimaryFlow/CompletionScreen/index.tsx
@@ -261,6 +261,7 @@ const CompletionScreen: FC = () => {
               <Image
                 src={avatarData.url}
                 alt="Generated Billionaire Avatar"
+                sizes="(orientation: landscape) 50vw, (max-width: 768px) 90vw, 30vw"
                 fill
                 className={`object-cover object-top transition-opacity duration-500 ${
                   imageLoaded ? 'opacity-100' : 'opacity-0'
@@ -275,7 +276,7 @@ const CompletionScreen: FC = () => {
             <BrowserBento inverse className="absolute w-[20.4375rem] landscape:w-[26.6875rem]">
               <div className="p-4">
                 <div className="text-lg font-bold mb-1 text-charcoal">
-                  Meet <span className="text-purple-600">{avatarData.name}</span>
+                  Meet <span className="text-purple-600 capitalize">{avatarData.name}</span>
                 </div>
                 <div className="text-sm text-charcoal">{avatarData.bio}</div>
               </div>

--- a/apps/web/src/components/PrimaryFlow/GetStarted/index.tsx
+++ b/apps/web/src/components/PrimaryFlow/GetStarted/index.tsx
@@ -3,6 +3,7 @@
 import { choiceGroupMap } from '@/constants/choice-map';
 import { useDisclosure } from '@heroui/react';
 import { AnimatePresence, motion } from 'framer-motion';
+import { useParams } from 'next/navigation';
 import { type FC } from 'react';
 import Modal from '../../Modal';
 import ChoiceBento from '../ChoiceBento';
@@ -23,8 +24,11 @@ export interface GetStartedProps extends IntroProps {
 }
 
 const GetStarted: FC<GetStartedProps> = ({ ctaText, triggerClassNames, ...babFlowData }) => {
+  const pathParams = useParams<{ id?: string }>();
   const { isOpen, onOpen, onOpenChange } = useDisclosure();
   const { activeGroup, showConfirmation, userChoices, reset } = usePrimaryFlowContext();
+
+  if (pathParams.id) return null;
 
   // Check if all choices are completed
   const totalGroups = Object.keys(choiceGroupMap).length;

--- a/apps/web/src/components/ShareAvatar/index.tsx
+++ b/apps/web/src/components/ShareAvatar/index.tsx
@@ -97,11 +97,12 @@ const ShareAvatar: FC<ShareAvatarProps> = ({
       };
 
       await navigator.share(sharePayload);
-    } catch (e: any) {
+    } catch (e: unknown) {
+      const error = e as { name: string };
       /**
        * User cancelled share action - no action needed
        */
-      if ('name' in e && e.name === 'AbortError') return;
+      if ('name' in error && error.name === 'AbortError') return;
       console.error(e);
     }
   };

--- a/apps/web/src/utils/actions/save-user-avatar.ts
+++ b/apps/web/src/utils/actions/save-user-avatar.ts
@@ -13,5 +13,5 @@ import { redirect } from 'next/navigation';
 export async function saveUserAvatar(uuid: string) {
   const cookieStore = await cookies();
   cookieStore.set(COOKIE_NAME, uuid);
-  redirect(`/a/${uuid}`);
+  return redirect(`/a/${uuid}`);
 }

--- a/apps/web/src/utils/constants.ts
+++ b/apps/web/src/utils/constants.ts
@@ -1,5 +1,23 @@
+import type { AvatarBentoProps } from '@/components/PrimaryFlow/AvatarBento';
+
 export const BUCKET_NAME = 'billionaires';
 export const COOKIE_NAME = 'user_id';
 export const ID_HISTORY_COOKIE = 'id_history';
 export const DEFAULT_AVATAR_WIDTH = 500;
 export const DEFAULT_AVATAR_HEIGHT = 600;
+
+export const avatarBentoData: AvatarBentoProps = {
+  primaryFlowData: {
+    triggerClassNames:
+      'absolute left-[5rem] landscape:left-[8.125rem] top-[17rem] landscape:top-[18.5rem] px-[3rem] landscape:px-[2.125rem] py-[0.75rem] bg-charcoal/30 rotate-[9deg] landscape:rotate-0 transition-[bg-color, color] transition-transform duration-600 group-hover:rotate-[-12deg] group-hover:bg-accent group-hover:text-charcoal',
+    ctaText: 'Get Started',
+    title: 'Make Space a Better Place. Add a Billionaire.',
+    description:
+      'Why should billionaires be the only ones sending billionaires to space? WE want to send billionaires to space! Build your own and reclaim your data independence!',
+    createAvatarCtaText: 'Start Building Your Billionaire',
+    randomAvatarCtaText: 'Create a Random Billionaire',
+  },
+  imageSrcLandscape: '/assets/images/avatar-square.webp',
+  imageSrcPortrait: '/assets/images/avatar-portrait.png',
+  imageAlt: '', // Decorative image
+};


### PR DESCRIPTION
- Include avatar gen flow in footer and countdown. This requires the context to be moved to the top and a small client wrapper in the page with the ID to set the data since the footer lives in the layout. Also, the button will NOT be displayed if the avatar is already generated (only when a user has confirmed selection and navigated to avatar uuuid path).
- Capitalize billionaire name now that we get it in lowercase from the API.
- Improve avatar image perf by including sizes.
- Fix a lint warning.
- Fix a redirection error caused by not retuning the function (was not causing issues other than an error log in the console).
- Fix the random flow since it was not letting users confirm the selection and was directly redirecting.