### PR TITLE
feat: selfie gen modal

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -27,6 +27,7 @@
     "react-dom": "19.1.0",
     "react-qr-code": "^2.0.18",
     "supabase": "^2.40.7",
+    "swiper": "^12.0.2",
     "tailwind-plugin": "link:@heroui/react/tailwind-plugin"
   },
   "devDependencies": {

--- a/apps/web/src/app/a/[id]/page.tsx
+++ b/apps/web/src/app/a/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { getUserAvatar } from '@/utils/actions/get-user-avatar';
-import SharedPage from '../../shared-page';
-import { redirect } from 'next/navigation';
+import { notFound } from 'next/navigation';
 import ClientPageWrapper from '../../../utils/page.client';
+import SharedPage from '../../shared-page';
 
 interface PageProps {
   params: Promise<{ id: string }>;
@@ -12,7 +12,7 @@ export default async function DynamicPage({ params }: PageProps) {
 
   const avatarData = await getUserAvatar(id);
 
-  if (!avatarData?.url) return redirect('/');
+  if (!avatarData?.url) return notFound();
 
   return (
     <ClientPageWrapper avatarData={avatarData}>

--- a/apps/web/src/components/BentoPlaypenSelfie/index.tsx
+++ b/apps/web/src/components/BentoPlaypenSelfie/index.tsx
@@ -1,61 +1,139 @@
 'use client';
 
-import { FC, useState } from 'react';
-import Bento from '../Bento';
-import Image from 'next/image';
-import { Button } from '@heroui/react';
 import { generateAvatarSelfie } from '@/utils/actions/generate-avatar-selfie';
+import { Button, useDisclosure } from '@heroui/react';
+import Image from 'next/image';
+import { FC, useEffect, useMemo, useState } from 'react';
+import Bento from '../Bento';
+import PlaypenPopup from '../PlaypenPopup';
+import Carousel from '../PrimaryFlow/Carousel';
 import { usePrimaryFlowContext } from '../PrimaryFlow/PrimaryFlowContext';
 import ProgressBar from '../ProgressBar';
+import { useAvatarActions } from '@/hooks';
+import ShareAvatar from '../ShareAvatar';
+import { useWindowSize } from '@/hooks/useWindowSize';
 
 const BentoPlaypenSelfie: FC = () => {
-  const { setAvatarData } = usePrimaryFlowContext();
+  const { onOpenChange } = useDisclosure();
+  const { setAvatarData, setShowVault, showVault, avatarData } = usePrimaryFlowContext();
+  const resolution = useWindowSize();
+  const { isNavigatorShareAvailable } = useAvatarActions({ avatar: avatarData });
   const [isGeneratingSelfie, setIsGeneratingSelfie] = useState(false);
+  const swiperOptions = useMemo(
+    () => ({
+      spaceBetween: resolution === 'landscape' ? -400 : -10,
+      slidesPerView: resolution === 'landscape' ? 3 : 1,
+      watchSlidesProgress: true,
+      speed: 800,
+      effect: 'slide',
+    }),
+    [resolution],
+  );
+
+  const vaultImages = useMemo(() => {
+    if (!avatarData) return [];
+
+    const parsedSelfies = avatarData.selfies.map((s) => s.asset);
+    return [...parsedSelfies, avatarData.url].filter(Boolean) as string[];
+  }, [avatarData]);
+
+  const handleClose = () => {
+    setShowVault(false);
+    onOpenChange();
+  };
+
   return (
-    <Bento
-      className={`h-full py-8 flex flex-col justify-center items-center gap-2 border-accent!
+    <>
+      <Bento
+        className={`h-full py-8 flex flex-col justify-center items-center gap-2 border-accent!
                  relative group hover:cursor-pointer
                  ${
                    isGeneratingSelfie
                      ? 'bg-gradient-to-br from-common-ash to-accent'
                      : 'bg-common-ash! hover:bg-gradient-to-br hover:bg-gradient-to-r hover:from-secondary-blue hover:to-secondary-purple'
                  }`}
-    >
-      <Image
-        src="/assets/images/icons/camera.webp"
-        width={60}
-        height={70}
-        className="group-hover:-rotate-5 transition-transform duration-300 h-auto w-auto"
-        alt=""
-        priority
-      />
-      {!isGeneratingSelfie ? (
-        <Button
-          onPress={async () => {
-            try {
-              setIsGeneratingSelfie(true);
-              const selfie = await generateAvatarSelfie();
-              if (!selfie) return;
+      >
+        <Image
+          src="/assets/images/icons/camera.webp"
+          width={60}
+          height={70}
+          className="group-hover:-rotate-5 transition-transform duration-300 h-auto w-auto"
+          alt=""
+          priority
+        />
+        {!isGeneratingSelfie ? (
+          <Button
+            onPress={async () => {
+              try {
+                setIsGeneratingSelfie(true);
+                const selfie = await generateAvatarSelfie();
+                if (!selfie) return;
 
-              setAvatarData((data) => {
-                if (!data) return data;
+                setAvatarData((data) =>
+                  !data ? data : { ...data, selfies: [...data.selfies, selfie] },
+                );
 
-                return { ...data, selfies: [...data.selfies, selfie] };
-              });
-            } catch {
-              // Do nothing.
-            } finally {
-              setIsGeneratingSelfie(false);
-            }
-          }}
-          className="secondary-button border-charcoal text-charcoal group-hover:bg-accent group-hover:border-accent group-hover:-rotate-5 group-hover:scale-105 transition-transform duration-300"
-        >
-          Take a space selfie
-        </Button>
-      ) : (
-        <ProgressBar duration={12000} />
-      )}
-    </Bento>
+                setShowVault(true);
+              } catch (e) {
+                // Do nothing.
+              } finally {
+                setIsGeneratingSelfie(false);
+              }
+            }}
+            className="secondary-button border-charcoal text-charcoal group-hover:bg-accent group-hover:border-accent group-hover:-rotate-5 group-hover:scale-105 transition-transform duration-300"
+          >
+            Take a space selfie
+          </Button>
+        ) : (
+          <ProgressBar duration={12000} />
+        )}
+        <PlaypenPopup title="Your billionaire vault" isOpen={showVault} onOpenChange={handleClose}>
+          <div className="w-full h-[70vh] flex flex-col items-center justify-center my-6">
+            <h3 className="text-title-3 text-center">Your Billionaire Vault</h3>
+            <p className="text-center max-w-[625px]">
+              This is your gallery of everything you and your Billionaire have done together. Every
+              dance, every selfie, every successful launch into space. You’re always welcome back to
+              reminisce.
+            </p>
+            <div className="w-full my-6">
+              <Carousel
+                containerClassName="w-full max-w-[44rem]"
+                swiperOptions={swiperOptions}
+                withArrowNavigation={resolution === 'landscape'}
+                slides={vaultImages.map((img, i) => (
+                  <div key={i} className="flex justify-center items-center">
+                    <Image
+                      src={img}
+                      width={300}
+                      height={300}
+                      className="rounded-xl max-w-[300px] landscape:hidden"
+                      alt=""
+                      priority
+                    />
+                    <Image
+                      src={img}
+                      width={466}
+                      height={466}
+                      className="rounded-xl hidden w-auto max-w-[466px] landscape:block"
+                      alt=""
+                      priority
+                    />
+                  </div>
+                ))}
+              />
+            </div>
+            {avatarData && (
+              <ShareAvatar
+                avatar={avatarData}
+                navigatorShareAvailable={isNavigatorShareAvailable}
+                onBookmarkClick={() => {}}
+                centered
+              />
+            )}
+          </div>
+        </PlaypenPopup>
+      </Bento>
+    </>
   );
 };
 

--- a/apps/web/src/components/PlaypenPopup/PlaypenRestart.tsx
+++ b/apps/web/src/components/PlaypenPopup/PlaypenRestart.tsx
@@ -3,8 +3,7 @@
 import Bento from '@/components/Bento';
 import { Close } from '@/components/PlaypenPopup/Close.svg';
 import { Delete } from '@/components/PlaypenPopup/Delete.svg';
-import { AvatarViewAction } from '@/components/PrimaryFlow/AvatarBento/AvatarView';
-import { AvatarData } from '@/types';
+import { AvatarData, type Action } from '@/types';
 import { COOKIE_NAME, ID_HISTORY_COOKIE } from '@/utils/constants';
 import { deleteCookie, getCookie, parseJsonCookie, setCookie } from '@/utils/helpers/cookies';
 import { Button } from '@heroui/react';
@@ -12,7 +11,7 @@ import Image from 'next/image';
 import { FC, useMemo } from 'react';
 
 interface PlaypenRestartProps {
-  action: AvatarViewAction;
+  action: Action;
   avatar: AvatarData;
   onCancel: () => void;
   asset?: 'riding' | 'instagram';

--- a/apps/web/src/components/PlaypenPopup/PlaypenSave.tsx
+++ b/apps/web/src/components/PlaypenPopup/PlaypenSave.tsx
@@ -1,14 +1,14 @@
 'use client';
 
 import { Link } from '@/components/PlaypenPopup/Link.svg';
-import { AvatarViewAction } from '@/components/PrimaryFlow/AvatarBento/AvatarView';
+import type { Action } from '@/types';
 import { Button } from '@heroui/react';
 import clsx from 'clsx';
 import { FC, useEffect, useState } from 'react';
 import QRCode from 'react-qr-code';
 
 interface PlaypenSaveProps {
-  action: AvatarViewAction;
+  action: Action;
   /**
    * Applies alternate styling to align with AvatarBentoV2 screens.
    */

--- a/apps/web/src/components/PlaypenPopup/PlaypenShare.tsx
+++ b/apps/web/src/components/PlaypenPopup/PlaypenShare.tsx
@@ -1,8 +1,7 @@
 import Bento from '@/components/Bento';
 import BrowserBento from '@/components/BrowserBento';
-import { AvatarViewAction } from '@/components/PrimaryFlow/AvatarBento/AvatarView';
 import ShareAvatar from '@/components/ShareAvatar';
-import { AvatarData } from '@/types';
+import { AvatarData, type Action } from '@/types';
 import Image from 'next/image';
 import { Dispatch, SetStateAction } from 'react';
 
@@ -11,7 +10,7 @@ const microcopy = {
 } as const;
 
 interface PlaypenShareProps<T = string> {
-  action: AvatarViewAction;
+  action: Action;
   avatar: AvatarData;
   navigatorShareAvailable: boolean;
   setActionType: Dispatch<SetStateAction<T | null>>;

--- a/apps/web/src/components/PrimaryFlow/AvatarBento/AvatarView.tsx
+++ b/apps/web/src/components/PrimaryFlow/AvatarBento/AvatarView.tsx
@@ -4,23 +4,12 @@ import PlaypenPopup from '@/components/PlaypenPopup';
 import PlaypenRestart from '@/components/PlaypenPopup/PlaypenRestart';
 import PlaypenSave from '@/components/PlaypenPopup/PlaypenSave';
 import PlaypenShare from '@/components/PlaypenPopup/PlaypenShare';
-import type { AvatarData } from '@/types';
+import { type Action, type ActionType, type ActionTypeOrNull, type AvatarData } from '@/types';
 import { Button } from '@heroui/react';
 import Image from 'next/image';
 import { Fragment, useEffect, useMemo, useState, type FC } from 'react';
 import BrowserBento from '../../BrowserBento';
-
-const actionTypes = ['share', 'save', 'restart'] as const;
-export type AvatarViewActionType = (typeof actionTypes)[number];
-export type AvatarViewActionTypeOrNull = AvatarViewActionType | null;
-
-export type AvatarViewAction = {
-  onPress: () => void;
-  content: {
-    title: string;
-    description: string;
-  };
-};
+import { actionTypes } from '@/utils/constants';
 
 const actionButtonStyles =
   'min-w-[6.0625rem] px-[0.625rem] border border-accent font-bold text-[0.875rem] leading-[1.25rem] text-accent rounded-full h-[2rem] cursor-pointer hover:text-charcoal hover:bg-accent transition-colors duration-300 gap-[0.375rem] flex items-center justify-center [&:hover_img]:brightness-50';
@@ -38,7 +27,7 @@ const AvatarView: FC<AvatarData> = ({
   selfies,
 }) => {
   const [navigatorShareAvailable, setNavigatorShareAvailable] = useState<boolean>(false);
-  const [actionType, setActionType] = useState<AvatarViewActionTypeOrNull>(null);
+  const [actionType, setActionType] = useState<ActionTypeOrNull>(null);
 
   useEffect(() => {
     /**
@@ -54,7 +43,7 @@ const AvatarView: FC<AvatarData> = ({
     if (!open) setActionType(null);
   };
 
-  const actions: Record<AvatarViewActionType, AvatarViewAction> = useMemo(
+  const actions: Record<ActionType, Action> = useMemo(
     () => ({
       share: {
         onPress: () => setActionType('share'),
@@ -135,7 +124,7 @@ const AvatarView: FC<AvatarData> = ({
                   onOpenChange={handleModalClose}
                 >
                   {actionName === 'share' && (
-                    <PlaypenShare<AvatarViewActionType>
+                    <PlaypenShare<ActionType>
                       action={action}
                       navigatorShareAvailable={navigatorShareAvailable}
                       avatar={{

--- a/apps/web/src/components/PrimaryFlow/Carousel/index.tsx
+++ b/apps/web/src/components/PrimaryFlow/Carousel/index.tsx
@@ -1,0 +1,115 @@
+import { Navigation, A11y } from 'swiper/modules';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import type { SwiperOptions } from 'swiper/types';
+
+import 'swiper/css';
+import 'swiper/css/navigation';
+import { useMemo, type FC, type ReactNode } from 'react';
+
+type CarouselProps = {
+  slides: ReactNode[];
+  slideClassName?: string;
+  containerClassName?: string;
+  swiperOptions?: Partial<SwiperOptions>;
+  withArrowNavigation?: boolean;
+};
+
+const Carousel: FC<CarouselProps> = ({
+  slides,
+  slideClassName,
+  containerClassName,
+  swiperOptions = {},
+  withArrowNavigation,
+}) => {
+  const defaultOptions: Partial<SwiperOptions> = useMemo(
+    () => ({
+      modules: [Navigation, A11y],
+      centeredSlides: true,
+      loop: true,
+      navigation: {
+        prevEl: '.swiper-button-prev',
+        nextEl: '.swiper-button-next',
+      },
+    }),
+    [],
+  );
+
+  const mergedOptions = useMemo(
+    () => ({ ...defaultOptions, ...swiperOptions }),
+    [defaultOptions, swiperOptions],
+  );
+
+  return (
+    <div className="relative overflow-visible">
+      <Swiper {...mergedOptions} className={containerClassName}>
+        {slides.map((slide, index) => (
+          <SwiperSlide
+            key={index}
+            className={`${slideClassName}
+            !scale-75 !brightness-50 !z-2
+            [&.swiper-slide-active]:!z-10 [&.swiper-slide-active]:!scale-100 [&.swiper-slide-active]:!brightness-100
+            [&.swiper-slide-next]:!z-8 [&.swiper-slide-next]:!scale-90 [&.swiper-slide-next]:!brightness-75
+            [&.swiper-slide-prev]:!z-8 [&.swiper-slide-prev]:!scale-90 [&.swiper-slide-prev]:!brightness-75
+            !transition-all !duration-700 ease-out`}
+          >
+            {slide}
+          </SwiperSlide>
+        ))}
+      </Swiper>
+
+      {withArrowNavigation && (
+        <>
+          {' '}
+          <button
+            className="rounded-full swiper-button-prev w-[2.75rem] h-[2.75rem] !left-4 bg-accent p-0"
+            aria-label="Show previous slide"
+          >
+            <span className="w-[1.375rem] h-[1.375rem]">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="none"
+              >
+                <path
+                  d="M14.1602 5.22168L8.66016 11.6383L14.1602 18.055"
+                  stroke="#333336"
+                  strokeWidth="1.65"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  fill="none"
+                />
+              </svg>
+            </span>
+          </button>
+          <button
+            className="rounded-full swiper-button-next w-[2.75rem] h-[2.75rem] !right-4 bg-accent p-0"
+            aria-label="Show next slide"
+          >
+            <span className="w-[1.375rem] h-[1.375rem]">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="none"
+              >
+                <path
+                  d="M8.83887 5.22168L14.3389 11.6383L8.83887 18.055"
+                  stroke="#333336"
+                  strokeWidth="1.65"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  fill="none"
+                />
+              </svg>
+            </span>
+          </button>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default Carousel;

--- a/apps/web/src/components/PrimaryFlow/PrimaryFlowContext.tsx
+++ b/apps/web/src/components/PrimaryFlow/PrimaryFlowContext.tsx
@@ -28,6 +28,8 @@ interface PrimaryFlowContextValue {
   setShowConfirmation: Dispatch<SetStateAction<ChoiceGroup | null>>;
   avatarData: AvatarData | null;
   setAvatarData: Dispatch<SetStateAction<AvatarData | null>>;
+  showVault: boolean;
+  setShowVault: Dispatch<SetStateAction<boolean>>;
   reset: () => void;
 }
 
@@ -39,6 +41,7 @@ export const PrimaryContextProvider: FC<PropsWithChildren<{ initialData: AvatarD
 }) => {
   const [activeGroup, setActiveGroup] = useState<ChoiceGroup | null>(null);
   const [showConfirmation, setShowConfirmation] = useState<ChoiceGroup | null>(null);
+  const [showVault, setShowVault] = useState(false);
   const [avatarData, setAvatarData] = useState<AvatarData | null>(initialData);
   const [userChoices, setUserChoices] =
     useState<Record<ChoiceGroup, ChoiceConfig | null>>(initialChoices);
@@ -61,6 +64,8 @@ export const PrimaryContextProvider: FC<PropsWithChildren<{ initialData: AvatarD
         setShowConfirmation,
         avatarData,
         setAvatarData,
+        showVault,
+        setShowVault,
         reset,
       }}
     >

--- a/apps/web/src/components/ProgressBar/index.tsx
+++ b/apps/web/src/components/ProgressBar/index.tsx
@@ -27,7 +27,7 @@ const ProgressBar: FC<ProgressBarProps> = ({ className = '', duration = 4000 }) 
     };
 
     requestAnimationFrame(animate);
-  }, []);
+  }, [duration]);
 
   return (
     <div className={`w-full px-4 ${className}`}>

--- a/apps/web/src/components/ShareAvatar/index.tsx
+++ b/apps/web/src/components/ShareAvatar/index.tsx
@@ -13,12 +13,14 @@ export interface ShareAvatarProps {
   avatar: AvatarData;
   onBookmarkClick: () => void;
   navigatorShareAvailable?: boolean;
+  centered?: boolean;
 }
 
 const ShareAvatar: FC<ShareAvatarProps> = ({
   avatar,
   onBookmarkClick,
   navigatorShareAvailable: externalNavigatorShareAvailable,
+  centered,
 }) => {
   const {
     isNavigatorShareAvailable,
@@ -35,7 +37,7 @@ const ShareAvatar: FC<ShareAvatarProps> = ({
 
   return (
     <nav aria-label="Share billionaire">
-      <ul className="flex items-start gap-x-4">
+      <ul className={`flex items-start gap-x-4 ${centered && 'justify-center'}`}>
         <li>
           {navigatorShareAvailable ? (
             <button type="button" className="block cursor-pointer" onClick={handleNavigatorShare}>

--- a/apps/web/src/hooks/useAvatarActions.ts
+++ b/apps/web/src/hooks/useAvatarActions.ts
@@ -8,7 +8,7 @@ import { useSafeClick } from './useSafeClick';
 import { useShareUrls } from './useShareUrls';
 
 export interface UseAvatarActionsOptions {
-  avatar: AvatarData;
+  avatar: AvatarData | null;
 }
 
 export interface UseAvatarActionsReturn {

--- a/apps/web/src/hooks/useAvatarDownload.ts
+++ b/apps/web/src/hooks/useAvatarDownload.ts
@@ -6,7 +6,7 @@ import { useEffect, useState } from 'react';
 const AVATAR_FILE_TYPE = 'png';
 
 export interface UseAvatarDownloadOptions {
-  avatar: AvatarData;
+  avatar: AvatarData | null;
 }
 
 export interface UseAvatarDownloadReturn {
@@ -29,7 +29,7 @@ export const useAvatarDownload = ({
 }: UseAvatarDownloadOptions): UseAvatarDownloadReturn => {
   const [downloadFile, setDownloadFile] = useState<{ href: string; fileName: string }>({
     href: '#',
-    fileName: `${avatar.name.replaceAll(' ', '-')}.${AVATAR_FILE_TYPE}`,
+    fileName: `${avatar?.name.replaceAll(' ', '-')}.${AVATAR_FILE_TYPE}`,
   });
 
   const isDownloadReady = downloadFile.href !== '#';
@@ -39,6 +39,8 @@ export const useAvatarDownload = ({
 
     const prepDownloadFile = async (): Promise<void> => {
       try {
+        if (!avatar?.instragramAsset || avatar?.name) return;
+
         const response = await fetch(avatar.instragramAsset);
         const blob = await response.blob();
         fileHref = URL.createObjectURL(blob);
@@ -57,7 +59,7 @@ export const useAvatarDownload = ({
     return () => {
       if (fileHref) URL.revokeObjectURL(fileHref);
     };
-  }, [avatar.instragramAsset, avatar.name]);
+  }, [avatar?.instragramAsset, avatar?.name]);
 
   return {
     downloadFile,

--- a/apps/web/src/hooks/useNavigatorShareAction.ts
+++ b/apps/web/src/hooks/useNavigatorShareAction.ts
@@ -12,7 +12,7 @@ const microcopy = {
 } as const;
 
 export interface UseNavigatorShareActionOptions {
-  avatar: AvatarData;
+  avatar: AvatarData | null;
 }
 
 export interface UseNavigatorShareActionReturn {
@@ -31,6 +31,8 @@ export const useNavigatorShareAction = ({
 }: UseNavigatorShareActionOptions): UseNavigatorShareActionReturn => {
   const handleNavigatorShare = useCallback(async (): Promise<void> => {
     try {
+      if (!avatar?.instragramAsset || !avatar?.name) return;
+
       const response = await fetch(avatar.instragramAsset);
       const blob = await response.blob();
 
@@ -54,7 +56,7 @@ export const useNavigatorShareAction = ({
       if ('name' in error && error.name === 'AbortError') return;
       console.error('Navigator share error:', e);
     }
-  }, [avatar.name, avatar.instragramAsset]);
+  }, [avatar?.name, avatar?.instragramAsset]);
 
   return {
     handleNavigatorShare,

--- a/apps/web/src/hooks/useWindowSize.ts
+++ b/apps/web/src/hooks/useWindowSize.ts
@@ -1,0 +1,20 @@
+import { useLayoutEffect, useState } from 'react';
+
+export function useWindowSize() {
+  const [size, setSize] = useState<'portrait' | 'landscape' | null>(null);
+
+  useLayoutEffect(() => {
+    const handleResize = () => {
+      setSize(window.innerWidth > window.innerHeight ? 'landscape' : 'portrait');
+    };
+
+    handleResize();
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  return size;
+}

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -1,3 +1,4 @@
+import type { actionTypes } from '@/utils/constants';
 import type { Database } from './database.types';
 
 export interface FlagType<T = boolean> {
@@ -137,4 +138,15 @@ export type SelfieStatusResponse = {
 
 export type StatusEndpointBaseResponse = {
   status: string;
+};
+
+export type ActionType = (typeof actionTypes)[number];
+export type ActionTypeOrNull = ActionType | null;
+
+export type Action = {
+  onPress: () => void;
+  content: {
+    title: string;
+    description: string;
+  };
 };

--- a/apps/web/src/utils/constants.ts
+++ b/apps/web/src/utils/constants.ts
@@ -21,3 +21,5 @@ export const avatarBentoData: AvatarBentoProps = {
   imageSrcPortrait: '/assets/images/avatar-portrait.png',
   imageAlt: '', // Decorative image
 };
+
+export const actionTypes = ['share', 'save', 'restart'] as const;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       supabase:
         specifier: ^2.40.7
         version: 2.40.7
+      swiper:
+        specifier: ^12.0.2
+        version: 12.0.2
       tailwind-plugin:
         specifier: link:@heroui/react/tailwind-plugin
         version: link:@heroui/react/tailwind-plugin
@@ -7485,6 +7488,10 @@ packages:
     resolution: {integrity: sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==}
     peerDependencies:
       react: '>=17.0'
+
+  swiper@12.0.2:
+    resolution: {integrity: sha512-y8F6fDGXmTVVgwqJj6I00l4FdGuhpFJn0U/9Ucn1MwWOw3NdLV8aH88pZOjyhBgU/6PyBlUx+JuAQ5KMWz906Q==}
+    engines: {node: '>= 4.7.0'}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -17772,6 +17779,8 @@ snapshots:
   suspend-react@0.1.3(react@19.1.1):
     dependencies:
       react: 19.1.1
+
+  swiper@12.0.2: {}
 
   symbol-tree@3.2.4: {}
 


### PR DESCRIPTION
- Implement vault modal. It will automatically open when the selfie generation is finished.
- Implement swiper carousel. There are minor tweaks to implement (for example in mobile the next selfie is not visible and in the designs there is a minor portion that should be visible) but in general this does the heavy lifting.


https://github.com/user-attachments/assets/782cf4f4-302b-449f-ba86-6c563b47340d
